### PR TITLE
Add hideOverlay configuration for bottom and top popup

### DIFF
--- a/Sources/Internal/Views/PopupView.swift
+++ b/Sources/Internal/Views/PopupView.swift
@@ -40,6 +40,7 @@ struct PopupView: View {
 // MARK: - Common Part
 private extension PopupView {
     func createBody() -> some View {
+        
         createPopupStackView()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(createOverlay())
@@ -56,10 +57,16 @@ private extension PopupView {
         .animation(stack.presenting ? globalConfig.common.animation.entry : globalConfig.common.animation.removal, value: stack.views.map(\.id))
     }
     func createOverlay() -> some View {
-        overlayColour
-            .ignoresSafeArea()
-            .active(if: !stack.views.isEmpty)
-            .animation(overlayAnimation, value: stack.views.isEmpty)
+        ZStack {
+            if globalConfig.bottom.hideOverlay || globalConfig.top.hideOverlay {
+                EmptyView()
+            } else {
+                overlayColour
+                    .ignoresSafeArea()
+                    .active(if: !stack.views.isEmpty)
+                    .animation(overlayAnimation, value: stack.views.isEmpty)
+            }
+        }
     }
 }
 

--- a/Sources/Public/Configurables/GlobalConfig.Bottom.swift
+++ b/Sources/Public/Configurables/GlobalConfig.Bottom.swift
@@ -54,6 +54,11 @@ public extension GlobalConfig.Bottom {
     func minimalDragThresholdToClose(_ value: CGFloat) -> Self { changing(path: \.dragGestureProgressToClose, to: value) }
 }
 
+// MARK: - Overlay
+public extension GlobalConfig.Bottom {
+    /// Hide the overlay
+    func hideOverlay(_ value: Bool) -> Self { changing(path: \.hideOverlay, to: value) }
+}
 
 // MARK: - Internal
 public extension GlobalConfig { struct Bottom: Configurable { public init() {}
@@ -70,4 +75,6 @@ public extension GlobalConfig { struct Bottom: Configurable { public init() {}
     private(set) var tapOutsideClosesView: Bool = false
     private(set) var dragGestureEnabled: Bool = true
     private(set) var dragGestureProgressToClose: CGFloat = 1/3
+    
+    private(set) var hideOverlay: Bool = false
 }}

--- a/Sources/Public/Configurables/GlobalConfig.Top.swift
+++ b/Sources/Public/Configurables/GlobalConfig.Top.swift
@@ -48,6 +48,12 @@ public extension GlobalConfig.Top {
     func minimalDragThresholdToClose(_ value: CGFloat) -> Self { changing(path: \.dragGestureProgressToClose, to: value) }
 }
 
+// MARK: - Overlay
+public extension GlobalConfig.Top {
+    /// Hide the overlay
+    func hideOverlay(_ value: Bool) -> Self { changing(path: \.hideOverlay, to: value) }
+}
+
 
 // MARK: - Internal
 public extension GlobalConfig { struct Top: Configurable { public init() {}
@@ -62,4 +68,5 @@ public extension GlobalConfig { struct Top: Configurable { public init() {}
     private(set) var tapOutsideClosesView: Bool = false
     private(set) var dragGestureEnabled: Bool = true
     private(set) var dragGestureProgressToClose: CGFloat = 1/3
+    private(set) var hideOverlay: Bool = false
 }}

--- a/Sources/Public/Configurables/LocalConfig.BottomPopup.swift
+++ b/Sources/Public/Configurables/LocalConfig.BottomPopup.swift
@@ -51,6 +51,12 @@ public extension BottomPopupConfig {
     func dragGestureEnabled(_ value: Bool) -> Self { changing(path: \.dragGestureEnabled, to: value) }
 }
 
+// MARK: - Overlay
+public extension BottomPopupConfig {
+    /// Hide the overlay
+    func hideOverlay(_ value: Bool) -> Self { changing(path: \.hideOverlay, to: value) }
+}
+
 
 // MARK: - Internal
 public struct BottomPopupConfig: Configurable { public init() {}
@@ -65,4 +71,6 @@ public struct BottomPopupConfig: Configurable { public init() {}
 
     private(set) var tapOutsideClosesView: Bool? = nil
     private(set) var dragGestureEnabled: Bool? = nil
+    
+    private(set) var hideOverlay: Bool = false
 }

--- a/Sources/Public/Configurables/LocalConfig.TopPopup.swift
+++ b/Sources/Public/Configurables/LocalConfig.TopPopup.swift
@@ -40,6 +40,12 @@ public extension TopPopupConfig {
     func dragGestureEnabled(_ value: Bool) -> Self { changing(path: \.dragGestureEnabled, to: value) }
 }
 
+// MARK: - Overlay
+public extension TopPopupConfig {
+    /// Hide the overlay
+    func hideOverlay(_ value: Bool) -> Self { changing(path: \.hideOverlay, to: value) }
+}
+
 
 // MARK: - Internal
 public struct TopPopupConfig: Configurable { public init() {}
@@ -51,4 +57,6 @@ public struct TopPopupConfig: Configurable { public init() {}
 
     private(set) var tapOutsideClosesView: Bool? = nil
     private(set) var dragGestureEnabled: Bool? = nil
+    
+    private(set) var hideOverlay: Bool = false
 }


### PR DESCRIPTION
This PR adds a hideOverlay option on the BottomPopup and TopPopup config, which will allow to mirror the behaviour of a toast (#56).