### PR TITLE
feat: Add AnchoredPopup support for absolute positioning

### DIFF
--- a/Sources/Internal/Configurables/Local/LocalConfig+Anchored.swift
+++ b/Sources/Internal/Configurables/Local/LocalConfig+Anchored.swift
@@ -22,6 +22,8 @@ public class LocalConfigAnchored: LocalConfig { required public init() {}
     public var popupAnchor: PopupAnchorPoint = .top
     public var offset: CGPoint = .zero
     public var isTapOutsidePassThroughEnabled: Bool = false
+    public var edgePadding: CGFloat = 16
+    public var constrainedEdges: Edge.Set = .horizontal
 
     // MARK: Inactive Variables (inherited from LocalConfig protocol)
     public var ignoredSafeAreaEdges: Edge.Set = []
@@ -48,6 +50,16 @@ public extension LocalConfigAnchored {
     /// Enables touch pass-through when tapping outside the popup
     /// When enabled, touches outside the popup are passed to underlying views instead of being blocked
     func tapOutsidePassThrough(_ enabled: Bool) -> Self { self.isTapOutsidePassThroughEnabled = enabled; return self }
+
+    /// Configures edge padding and which edges to constrain
+    /// - Parameters:
+    ///   - value: Padding value from screen edges
+    ///   - edges: Which edges to constrain (.horizontal, .vertical, .all, or [] to disable)
+    func edgePadding(_ value: CGFloat, edges: Edge.Set = .horizontal) -> Self {
+        self.edgePadding = value
+        self.constrainedEdges = edges
+        return self
+    }
 }
 
 // MARK: - Public Type Alias

--- a/Sources/Internal/Configurables/Local/LocalConfig+Anchored.swift
+++ b/Sources/Internal/Configurables/Local/LocalConfig+Anchored.swift
@@ -21,6 +21,7 @@ public class LocalConfigAnchored: LocalConfig { required public init() {}
     public var originAnchor: PopupAnchorPoint = .bottom
     public var popupAnchor: PopupAnchorPoint = .top
     public var offset: CGPoint = .zero
+    public var isTapOutsidePassThroughEnabled: Bool = false
 
     // MARK: Inactive Variables (inherited from LocalConfig protocol)
     public var ignoredSafeAreaEdges: Edge.Set = []
@@ -43,6 +44,10 @@ public extension LocalConfigAnchored {
 
     /// Sets additional offset from the calculated position
     func offset(x: CGFloat = 0, y: CGFloat = 0) -> Self { self.offset = CGPoint(x: x, y: y); return self }
+
+    /// Enables touch pass-through when tapping outside the popup
+    /// When enabled, touches outside the popup are passed to underlying views instead of being blocked
+    func tapOutsidePassThrough(_ enabled: Bool) -> Self { self.isTapOutsidePassThroughEnabled = enabled; return self }
 }
 
 // MARK: - Public Type Alias

--- a/Sources/Internal/Configurables/Local/LocalConfig+Anchored.swift
+++ b/Sources/Internal/Configurables/Local/LocalConfig+Anchored.swift
@@ -21,7 +21,7 @@ public class LocalConfigAnchored: LocalConfig { required public init() {}
     public var originAnchor: PopupAnchorPoint = .bottom
     public var popupAnchor: PopupAnchorPoint = .top
     public var offset: CGPoint = .zero
-    public var isTapOutsidePassThroughEnabled: Bool = false
+    public var tapOutsideBehavior: TapOutsideBehavior = .dismiss
     public var edgePadding: CGFloat = 16
     public var constrainedEdges: Edge.Set = .horizontal
 
@@ -47,9 +47,9 @@ public extension LocalConfigAnchored {
     /// Sets additional offset from the calculated position
     func offset(x: CGFloat = 0, y: CGFloat = 0) -> Self { self.offset = CGPoint(x: x, y: y); return self }
 
-    /// Enables touch pass-through when tapping outside the popup
-    /// When enabled, touches outside the popup are passed to underlying views instead of being blocked
-    func tapOutsidePassThrough(_ enabled: Bool) -> Self { self.isTapOutsidePassThroughEnabled = enabled; return self }
+    /// Sets behavior when tapping outside the popup
+    /// - Parameter behavior: The tap outside behavior (.none, .dismiss, .passThrough)
+    func tapOutsideBehavior(_ behavior: TapOutsideBehavior) -> Self { self.tapOutsideBehavior = behavior; return self }
 
     /// Configures edge padding and which edges to constrain
     /// - Parameters:

--- a/Sources/Internal/Configurables/Local/LocalConfig+Anchored.swift
+++ b/Sources/Internal/Configurables/Local/LocalConfig+Anchored.swift
@@ -1,0 +1,49 @@
+//
+//  LocalConfig+Anchored.swift of MijickPopups
+//
+//  Created by Vidy. Extending MijickPopups with anchored popup support.
+//
+//  Copyright 2024 Mijick. All rights reserved.
+
+
+import SwiftUI
+
+@MainActor
+public class LocalConfigAnchored: LocalConfig { required public init() {}
+    // MARK: Active Variables
+    public var popupPadding: EdgeInsets = GlobalConfigContainer.center.popupPadding
+    public var cornerRadius: CGFloat = GlobalConfigContainer.center.cornerRadius
+    public var backgroundColor: Color = GlobalConfigContainer.center.backgroundColor
+    public var overlayColor: Color = GlobalConfigContainer.center.overlayColor
+    public var isTapOutsideToDismissEnabled: Bool = true
+
+    // MARK: Anchored-specific Variables
+    public var originAnchor: PopupAnchorPoint = .bottom
+    public var popupAnchor: PopupAnchorPoint = .top
+    public var offset: CGPoint = .zero
+
+    // MARK: Inactive Variables (inherited from LocalConfig protocol)
+    public var ignoredSafeAreaEdges: Edge.Set = []
+    public var heightMode: HeightMode = .auto
+    public var dragDetents: [DragDetent] = []
+    public var isDragGestureEnabled: Bool = false
+    public var dragGestureAreaSize: CGFloat = 0
+}
+
+// MARK: - Chained Modifiers
+public extension LocalConfigAnchored {
+    /// Sets the anchor point on the source view (where the popup originates from)
+    func originAnchor(_ anchor: PopupAnchorPoint) -> Self { self.originAnchor = anchor; return self }
+
+    /// Sets the anchor point on the popup itself (which point aligns with origin)
+    func popupAnchor(_ anchor: PopupAnchorPoint) -> Self { self.popupAnchor = anchor; return self }
+
+    /// Sets additional offset from the calculated position
+    func offset(_ offset: CGPoint) -> Self { self.offset = offset; return self }
+
+    /// Sets additional offset from the calculated position
+    func offset(x: CGFloat = 0, y: CGFloat = 0) -> Self { self.offset = CGPoint(x: x, y: y); return self }
+}
+
+// MARK: - Public Type Alias
+public typealias AnchoredPopupConfig = LocalConfigAnchored

--- a/Sources/Internal/Containers/PopupStack.swift
+++ b/Sources/Internal/Containers/PopupStack.swift
@@ -34,7 +34,7 @@ extension PopupStack {
 // MARK: Modify
 extension PopupStack { enum StackOperation {
     case insertPopup(AnyPopup)
-    case removeLastPopup, removePopup(AnyPopup), removeAllPopupsOfType(any Popup.Type), removeAllPopupsWithID(String), removeAllPopups
+    case removeLastPopup, removePopup(AnyPopup), removeAllPopupsOfType(any Popup.Type), removeAllPopupsWithID(String), removeAllPopups, removeAllPopupsExcluding([String])
 }}
 extension PopupStack {
     func modify(_ operation: StackOperation) { Task {
@@ -67,6 +67,7 @@ private extension PopupStack {
         case .removeAllPopupsOfType(let popupType): await removedAllPopupsOfType(popupType)
         case .removeAllPopupsWithID(let id): await removedAllPopupsWithID(id)
         case .removeAllPopups: await removedAllPopups()
+        case .removeAllPopupsExcluding(let excludedIDs): await removedAllPopupsExcluding(excludedIDs)
     }}
     nonisolated func getNewPriority(_ newPopups: [AnyPopup]) async -> StackPriority {
         await priority.reshuffled(newPopups)
@@ -99,6 +100,11 @@ private extension PopupStack {
     }}
     nonisolated func removedAllPopups() async -> [AnyPopup] {
         []
+    }
+    nonisolated func removedAllPopupsExcluding(_ excludedIDs: [String]) async -> [AnyPopup] {
+        await popups.filter { popup in
+            excludedIDs.contains { popup.id.isSameType(as: $0) }
+        }
     }
 }
 

--- a/Sources/Internal/Extensions/EdgeInsets++.swift
+++ b/Sources/Internal/Extensions/EdgeInsets++.swift
@@ -16,5 +16,6 @@ extension EdgeInsets {
         case .top: top
         case .center: 0
         case .bottom: bottom
+        case .anchored: 0
     }}
 }

--- a/Sources/Internal/Models/AnyPopup.swift
+++ b/Sources/Internal/Models/AnyPopup.swift
@@ -61,7 +61,7 @@ extension AnyPopup {
     func updatedEnvironmentObject(_ environmentObject: some ObservableObject) -> AnyPopup { updated { $0._body = .init(_body.environmentObject(environmentObject)) }}
     func updatedKeyboardDismissal(_ shouldDismiss: Bool) -> AnyPopup { updated { $0.shouldDismissKeyboardOnPopupToggle = shouldDismiss }}
     func startDismissTimerIfNeeded(_ popupStack: PopupStack) -> AnyPopup { updated { $0._dismissTimer?.schedule { popupStack.modify(.removePopup(self)) }}}
-    func updatedAnchorFrame(_ frame: CGRect) -> AnyPopup { updated { $0.config.anchorFrame = frame }}
+    func updatedAnchorFrameProvider(_ provider: @escaping () -> CGRect) -> AnyPopup { updated { $0.config.anchorFrameProvider = .init(closure: provider) }}
 }
 private extension AnyPopup {
     func updated(_ customBuilder: (inout AnyPopup) -> ()) -> AnyPopup {

--- a/Sources/Internal/Models/AnyPopup.swift
+++ b/Sources/Internal/Models/AnyPopup.swift
@@ -61,6 +61,7 @@ extension AnyPopup {
     func updatedEnvironmentObject(_ environmentObject: some ObservableObject) -> AnyPopup { updated { $0._body = .init(_body.environmentObject(environmentObject)) }}
     func updatedKeyboardDismissal(_ shouldDismiss: Bool) -> AnyPopup { updated { $0.shouldDismissKeyboardOnPopupToggle = shouldDismiss }}
     func startDismissTimerIfNeeded(_ popupStack: PopupStack) -> AnyPopup { updated { $0._dismissTimer?.schedule { popupStack.modify(.removePopup(self)) }}}
+    func updatedAnchorFrame(_ frame: CGRect) -> AnyPopup { updated { $0.config.anchorFrame = frame }}
 }
 private extension AnyPopup {
     func updated(_ customBuilder: (inout AnyPopup) -> ()) -> AnyPopup {

--- a/Sources/Internal/Models/AnyPopup.swift
+++ b/Sources/Internal/Models/AnyPopup.swift
@@ -61,7 +61,8 @@ extension AnyPopup {
     func updatedEnvironmentObject(_ environmentObject: some ObservableObject) -> AnyPopup { updated { $0._body = .init(_body.environmentObject(environmentObject)) }}
     func updatedKeyboardDismissal(_ shouldDismiss: Bool) -> AnyPopup { updated { $0.shouldDismissKeyboardOnPopupToggle = shouldDismiss }}
     func startDismissTimerIfNeeded(_ popupStack: PopupStack) -> AnyPopup { updated { $0._dismissTimer?.schedule { popupStack.modify(.removePopup(self)) }}}
-    func updatedAnchorFrameProvider(_ provider: @escaping () -> CGRect) -> AnyPopup { updated { $0.config.anchorFrameProvider = .init(closure: provider) }}
+    func updatedAnchorID(_ anchorID: String) -> AnyPopup { updated { $0.config.anchorID = anchorID }}
+    func updatedAnchorFrame(_ frame: CGRect) -> AnyPopup { updated { $0.config.anchorFrame = frame }}
 }
 private extension AnyPopup {
     func updated(_ customBuilder: (inout AnyPopup) -> ()) -> AnyPopup {

--- a/Sources/Internal/Models/AnyPopupConfig.swift
+++ b/Sources/Internal/Models/AnyPopupConfig.swift
@@ -32,6 +32,7 @@ struct AnyPopupConfig: LocalConfig, Sendable { init() {}
     var originAnchor: PopupAnchorPoint = .bottom
     var popupAnchor: PopupAnchorPoint = .top
     var anchorOffset: CGPoint = .zero
+    var isTapOutsidePassThroughEnabled: Bool = false
 }
 
 // MARK: Initialize
@@ -54,6 +55,7 @@ extension AnyPopupConfig {
             self.originAnchor = anchoredConfig.originAnchor
             self.popupAnchor = anchoredConfig.popupAnchor
             self.anchorOffset = anchoredConfig.offset
+            self.isTapOutsidePassThroughEnabled = anchoredConfig.isTapOutsidePassThroughEnabled
         }
     }
 }

--- a/Sources/Internal/Models/AnyPopupConfig.swift
+++ b/Sources/Internal/Models/AnyPopupConfig.swift
@@ -11,6 +11,18 @@
 
 import SwiftUI
 
+/// Wrapper to bypass Sendable compiler checks for anchor frame closure.
+///
+/// This is safe because:
+/// 1. The closure only captures @State variables which are main-thread isolated in SwiftUI
+/// 2. The closure is only called from UI layer (main thread) in calculatePopupPosition()
+/// 3. No actual cross-thread access occurs - the Sendable requirement is only for
+///    passing AnyPopup through async boundaries, not for concurrent execution
+struct AnchorFrameProvider: @unchecked Sendable {
+    let closure: () -> CGRect
+    func callAsFunction() -> CGRect { closure() }
+}
+
 struct AnyPopupConfig: LocalConfig, Sendable { init() {}
     // MARK: Content
     var alignment: PopupAlignment = .center
@@ -28,11 +40,14 @@ struct AnyPopupConfig: LocalConfig, Sendable { init() {}
     var dragGestureAreaSize: CGFloat = 0
 
     // MARK: Anchored-specific
-    var anchorFrame: CGRect = .zero
+    var anchorFrameProvider: AnchorFrameProvider? = nil
+    var anchorFrame: CGRect { anchorFrameProvider?() ?? .zero }
     var originAnchor: PopupAnchorPoint = .bottom
     var popupAnchor: PopupAnchorPoint = .top
     var anchorOffset: CGPoint = .zero
     var isTapOutsidePassThroughEnabled: Bool = false
+    var edgePadding: CGFloat = 16
+    var constrainedEdges: Edge.Set = .horizontal
 }
 
 // MARK: Initialize
@@ -56,6 +71,8 @@ extension AnyPopupConfig {
             self.popupAnchor = anchoredConfig.popupAnchor
             self.anchorOffset = anchoredConfig.offset
             self.isTapOutsidePassThroughEnabled = anchoredConfig.isTapOutsidePassThroughEnabled
+            self.edgePadding = anchoredConfig.edgePadding
+            self.constrainedEdges = anchoredConfig.constrainedEdges
         }
     }
 }

--- a/Sources/Internal/Models/AnyPopupConfig.swift
+++ b/Sources/Internal/Models/AnyPopupConfig.swift
@@ -26,6 +26,12 @@ struct AnyPopupConfig: LocalConfig, Sendable { init() {}
     var isTapOutsideToDismissEnabled: Bool = false
     var isDragGestureEnabled: Bool = false
     var dragGestureAreaSize: CGFloat = 0
+
+    // MARK: Anchored-specific
+    var anchorFrame: CGRect = .zero
+    var originAnchor: PopupAnchorPoint = .bottom
+    var popupAnchor: PopupAnchorPoint = .top
+    var anchorOffset: CGPoint = .zero
 }
 
 // MARK: Initialize
@@ -42,5 +48,12 @@ extension AnyPopupConfig {
         self.isTapOutsideToDismissEnabled = config.isTapOutsideToDismissEnabled
         self.isDragGestureEnabled = config.isDragGestureEnabled
         self.dragGestureAreaSize = config.dragGestureAreaSize
+
+        // Anchored-specific properties
+        if let anchoredConfig = config as? LocalConfigAnchored {
+            self.originAnchor = anchoredConfig.originAnchor
+            self.popupAnchor = anchoredConfig.popupAnchor
+            self.anchorOffset = anchoredConfig.offset
+        }
     }
 }

--- a/Sources/Internal/Models/AnyPopupConfig.swift
+++ b/Sources/Internal/Models/AnyPopupConfig.swift
@@ -42,7 +42,9 @@ struct AnyPopupConfig: LocalConfig, Sendable { init() {}
     var originAnchor: PopupAnchorPoint = .bottom
     var popupAnchor: PopupAnchorPoint = .top
     var anchorOffset: CGPoint = .zero
-    var isTapOutsidePassThroughEnabled: Bool = false
+    var tapOutsideBehavior: TapOutsideBehavior = .dismiss
+    // MARK: Transition
+    var transition: AnyTransition? = nil
     var edgePadding: CGFloat = 16
     var constrainedEdges: Edge.Set = .horizontal
 }
@@ -67,7 +69,7 @@ extension AnyPopupConfig {
             self.originAnchor = anchoredConfig.originAnchor
             self.popupAnchor = anchoredConfig.popupAnchor
             self.anchorOffset = anchoredConfig.offset
-            self.isTapOutsidePassThroughEnabled = anchoredConfig.isTapOutsidePassThroughEnabled
+            self.tapOutsideBehavior = anchoredConfig.tapOutsideBehavior
             self.edgePadding = anchoredConfig.edgePadding
             self.constrainedEdges = anchoredConfig.constrainedEdges
         }

--- a/Sources/Internal/Models/AnyPopupConfig.swift
+++ b/Sources/Internal/Models/AnyPopupConfig.swift
@@ -11,18 +11,6 @@
 
 import SwiftUI
 
-/// Wrapper to bypass Sendable compiler checks for anchor frame closure.
-///
-/// This is safe because:
-/// 1. The closure only captures @State variables which are main-thread isolated in SwiftUI
-/// 2. The closure is only called from UI layer (main thread) in calculatePopupPosition()
-/// 3. No actual cross-thread access occurs - the Sendable requirement is only for
-///    passing AnyPopup through async boundaries, not for concurrent execution
-struct AnchorFrameProvider: @unchecked Sendable {
-    let closure: () -> CGRect
-    func callAsFunction() -> CGRect { closure() }
-}
-
 struct AnyPopupConfig: LocalConfig, Sendable { init() {}
     // MARK: Content
     var alignment: PopupAlignment = .center
@@ -40,8 +28,17 @@ struct AnyPopupConfig: LocalConfig, Sendable { init() {}
     var dragGestureAreaSize: CGFloat = 0
 
     // MARK: Anchored-specific
-    var anchorFrameProvider: AnchorFrameProvider? = nil
-    var anchorFrame: CGRect { anchorFrameProvider?() ?? .zero }
+    var anchorID: String? = nil  // ID for AnchorRegistry lookup
+    var anchorFrame: CGRect? = nil  // Static anchor frame (alternative to anchorID)
+    /// Returns the anchor frame - uses static frame if set, otherwise fetches from registry
+    func getAnchorFrame() -> CGRect {
+        if let staticFrame = anchorFrame {
+            return staticFrame
+        } else if let anchorID = anchorID {
+            return AnchorRegistry.frame(forKey: anchorID)
+        }
+        return .zero
+    }
     var originAnchor: PopupAnchorPoint = .bottom
     var popupAnchor: PopupAnchorPoint = .top
     var anchorOffset: CGPoint = .zero

--- a/Sources/Internal/Models/StackPriority.swift
+++ b/Sources/Internal/Models/StackPriority.swift
@@ -16,7 +16,7 @@ struct StackPriority: Equatable, Sendable {
     var center: CGFloat { values[1] }
     var bottom: CGFloat { values[2] }
     var anchored: CGFloat { values[3] }
-    var overlay: CGFloat { 1 }
+    var overlay: CGFloat { (values.min() ?? 0) - 1 }
 
     private var values: [CGFloat] = [0, 0, 0, 0]
 }

--- a/Sources/Internal/Models/StackPriority.swift
+++ b/Sources/Internal/Models/StackPriority.swift
@@ -15,9 +15,10 @@ struct StackPriority: Equatable, Sendable {
     var top: CGFloat { values[0] }
     var center: CGFloat { values[1] }
     var bottom: CGFloat { values[2] }
+    var anchored: CGFloat { values[3] }
     var overlay: CGFloat { 1 }
 
-    private var values: [CGFloat] = [0, 0, 0]
+    private var values: [CGFloat] = [0, 0, 0, 0]
 }
 
 // MARK: Reshuffled
@@ -26,6 +27,7 @@ extension StackPriority {
         case .top: reshuffled(0)
         case .center: reshuffled(1)
         case .bottom: reshuffled(2)
+        case .anchored: reshuffled(3)
         default: self
     }}
 }

--- a/Sources/Internal/Models/TapOutsideBehavior.swift
+++ b/Sources/Internal/Models/TapOutsideBehavior.swift
@@ -1,0 +1,19 @@
+//
+//  TapOutsideBehavior.swift of MijickPopups
+//
+//  Created by Vidy. Extending MijickPopups with anchored popup support.
+//
+//  Copyright 2024 Mijick. All rights reserved.
+
+
+import Foundation
+
+/// Defines behavior when tapping outside an AnchoredPopup
+public enum TapOutsideBehavior {
+    /// Does not dismiss, does not pass through (blocks tap)
+    case none
+    /// Dismisses popup, does not pass through
+    case dismiss
+    /// Passes through to underlying views, does not dismiss
+    case passThrough
+}

--- a/Sources/Internal/UI/PopupAnchoredStackView.swift
+++ b/Sources/Internal/UI/PopupAnchoredStackView.swift
@@ -170,7 +170,7 @@ private struct AnchoredPopupContainerView: View {
                 let popupId = popup.id.rawValue
                 let frame = model.frame(for: popup)
 
-                PopupContentView(popup: popup, viewModel: model.viewModel)
+                PopupContentView(popup: popup, viewModel: model.viewModel, containerSize: model.containerSize)
                     .opacity(frame != nil ? 1 : 0)
                     .sizeReader { size in
                         if model.popupSizes[popupId] != size {
@@ -189,9 +189,11 @@ private struct AnchoredPopupContainerView: View {
 private struct PopupContentView: View {
     let popup: AnyPopup
     var viewModel: VM.AnchoredStack?
+    var containerSize: CGSize
 
     var body: some View {
         popup.body
+            .environment(\.popupContainerSize, containerSize)
             .compositingGroup()
             .fixedSize(horizontal: false, vertical: viewModel?.activePopupProperties.verticalFixedSize ?? true)
             .background(backgroundColor: popup.config.backgroundColor, overlayColor: .clear, corners: viewModel?.activePopupProperties.corners ?? [:])

--- a/Sources/Internal/UI/PopupAnchoredStackView.swift
+++ b/Sources/Internal/UI/PopupAnchoredStackView.swift
@@ -7,85 +7,172 @@
 
 
 import SwiftUI
+import UIKit
 
-struct PopupAnchoredStackView: View {
-    @ObservedObject var viewModel: VM.AnchoredStack
+// MARK: - Anchored Popups Container (Added directly to Window, bypassing SwiftUI hierarchy)
 
+/// UIKit container managing multiple popup UIHostingControllers
+/// Added directly to Window, not through SwiftUI view hierarchy
+class AnchoredPopupsContainer: UIView {
+    static var shared: AnchoredPopupsContainer?
 
-    var body: some View { if viewModel.screen.height > 0 {
-        ZStack(alignment: .topLeading, content: createPopupStack)
-            .id(viewModel.popups.isEmpty)
-            .frame(maxWidth: .infinity, maxHeight: viewModel.screen.height)
-    }}
-}
-private extension PopupAnchoredStackView {
-    func createPopupStack() -> some View {
-        ForEach(viewModel.popups, id: \.self, content: createPopup)
+    private var popupViews: [String: UIView] = [:]
+    private var hostingControllers: [String: UIHostingController<AnyView>] = [:]
+
+    /// Returns false when touch is outside popup, allowing events to pass through to underlying views
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        for subview in subviews {
+            let convertedPoint = convert(point, to: subview)
+            if subview.point(inside: convertedPoint, with: event) {
+                return true
+            }
+        }
+        return false
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        for subview in subviews.reversed() {
+            let convertedPoint = convert(point, to: subview)
+            if let hitView = subview.hitTest(convertedPoint, with: event) {
+                return hitView
+            }
+        }
+        return nil
+    }
+
+    /// Updates popups in the container
+    func updatePopups(_ popups: [AnyPopup], viewModel: VM.AnchoredStack) {
+        let currentIds = Set(popups.map { $0.id.rawValue })
+        let existingIds = Set(popupViews.keys)
+
+        // Remove popups that no longer exist
+        for id in existingIds.subtracting(currentIds) {
+            popupViews[id]?.removeFromSuperview()
+            popupViews[id] = nil
+            hostingControllers[id] = nil
+        }
+
+        // Add or update popups
+        for popup in popups {
+            let id = popup.id.rawValue
+
+            if let existingView = popupViews[id] {
+                let actualSize = existingView.frame.size
+                let position = viewModel.calculatePopupPosition(for: popup, popupSize: actualSize)
+                var newFrame = existingView.frame
+                newFrame.origin = CGPoint(x: position.x, y: position.y)
+                existingView.frame = newFrame
+            } else {
+                let (hostingController, popupView) = createPopupView(for: popup, viewModel: viewModel)
+                popupView.sizeToFit()
+                let actualSize = popupView.frame.size
+                let position = viewModel.calculatePopupPosition(for: popup, popupSize: actualSize)
+                var frame = popupView.frame
+                frame.origin = CGPoint(x: position.x, y: position.y)
+                popupView.frame = frame
+                addSubview(popupView)
+                popupViews[id] = popupView
+                hostingControllers[id] = hostingController
+            }
+        }
+    }
+
+    private func createPopupView(for popup: AnyPopup, viewModel: VM.AnchoredStack) -> (UIHostingController<AnyView>, UIView) {
+        let content = AnyView(PopupContentView(popup: popup, viewModel: viewModel))
+        let hostingController = UIHostingController(rootView: content)
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = true
+        return (hostingController, hostingController.view)
+    }
+
+    /// Installs container directly on Window (above rootViewController.view)
+    static func install(on window: UIWindow) {
+        guard shared == nil else { return }
+        let container = AnchoredPopupsContainer()
+        container.backgroundColor = .clear
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        // Add directly to window, above rootViewController.view
+        window.addSubview(container)
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: window.topAnchor),
+            container.bottomAnchor.constraint(equalTo: window.bottomAnchor),
+            container.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: window.trailingAnchor)
+        ])
+        // Force layout to apply constraints
+        container.setNeedsLayout()
+        window.layoutIfNeeded()
+        shared = container
     }
 }
-private extension PopupAnchoredStackView {
-    func createPopup(_ popup: AnyPopup) -> some View {
-        PopupAnchoredContentView(popup: popup, viewModel: viewModel)
+
+/// SwiftUI content for a single popup
+private struct PopupContentView: View {
+    let popup: AnyPopup
+    @ObservedObject var viewModel: VM.AnchoredStack
+
+    var body: some View {
+        popup.body
+            .compositingGroup()
+            .fixedSize(horizontal: false, vertical: viewModel.activePopupProperties.verticalFixedSize)
+            .background(backgroundColor: popup.config.backgroundColor, overlayColor: .clear, corners: viewModel.activePopupProperties.corners)
             .opacity(viewModel.calculateOpacity(for: popup))
     }
 }
 
-// MARK: - Anchored Content View
-/// A wrapper view that measures popup size and positions it correctly
-private struct PopupAnchoredContentView: View {
-    let popup: AnyPopup
+// MARK: - Popup Anchored Stack View (Triggers installation and updates)
+
+struct PopupAnchoredStackView: View {
     @ObservedObject var viewModel: VM.AnchoredStack
-    @State private var popupSize: CGSize = .zero
 
     var body: some View {
-        let position = viewModel.calculatePopupPosition(for: popup, popupSize: popupSize)
+        // InstallerView is only used to get window reference and install container
+        // AnchoredPopupsContainer is added directly to Window, not in SwiftUI hierarchy
+        AnchoredStackInstaller(viewModel: viewModel)
+            .frame(width: 1, height: 1)
+    }
+}
 
-        popupContent
-            .background(GeometryReader { geometry in
-                Color.clear.preference(key: SizePreferenceKey.self, value: geometry.size)
-            })
-            .onPreferenceChange(SizePreferenceKey.self) { newSize in
-                if popupSize != newSize {
-                    popupSize = newSize
-                }
-            }
-            .offset(x: position.x, y: position.y)
-            .transition(transition)
+/// Used to get the current view's window and install the container
+private struct AnchoredStackInstaller: UIViewRepresentable {
+    @ObservedObject var viewModel: VM.AnchoredStack
+
+    func makeUIView(context: Context) -> InstallerView {
+        let view = InstallerView()
+        view.viewModel = viewModel
+        return view
     }
 
-    @ViewBuilder
-    private var popupContent: some View {
-        popup.body
-            .compositingGroup()
-            .fixedSize(horizontal: false, vertical: viewModel.activePopupProperties.verticalFixedSize)
-            .onHeightChange { await viewModel.updatePopupHeight($0, popup) }
-            .background(backgroundColor: popup.config.backgroundColor, overlayColor: .clear, corners: viewModel.activePopupProperties.corners)
-            .focusSection_tvOS()
+    func updateUIView(_ uiView: InstallerView, context: Context) {
+        uiView.viewModel = viewModel
+        uiView.updateIfNeeded()
+    }
+}
+
+private class InstallerView: UIView {
+    var viewModel: VM.AnchoredStack?
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        installContainerIfNeeded()
+        updatePopups()
     }
 
-    private var transition: AnyTransition {
-        .scale(scale: 0.9, anchor: transitionAnchor).combined(with: .opacity)
+    func updateIfNeeded() {
+        installContainerIfNeeded()
+        updatePopups()
     }
 
-    private var transitionAnchor: UnitPoint {
-        switch popup.config.popupAnchor {
-        case .topLeft: return .topLeading
-        case .top: return .top
-        case .topRight: return .topTrailing
-        case .left: return .leading
-        case .center: return .center
-        case .right: return .trailing
-        case .bottomLeft: return .bottomLeading
-        case .bottom: return .bottom
-        case .bottomRight: return .bottomTrailing
+    private func installContainerIfNeeded() {
+        guard AnchoredPopupsContainer.shared == nil, let window = window else { return }
+        AnchoredPopupsContainer.install(on: window)
+    }
+
+    private func updatePopups() {
+        if let viewModel = viewModel {
+            AnchoredPopupsContainer.shared?.updatePopups(viewModel.popups, viewModel: viewModel)
         }
     }
 }
 
-// MARK: - Size Preference Key
-private struct SizePreferenceKey: PreferenceKey {
-    nonisolated(unsafe) static var defaultValue: CGSize = .zero
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = nextValue()
-    }
-}

--- a/Sources/Internal/UI/PopupAnchoredStackView.swift
+++ b/Sources/Internal/UI/PopupAnchoredStackView.swift
@@ -1,0 +1,91 @@
+//
+//  PopupAnchoredStackView.swift of MijickPopups
+//
+//  Created by Vidy. Extending MijickPopups with anchored popup support.
+//
+//  Copyright 2024 Mijick. All rights reserved.
+
+
+import SwiftUI
+
+struct PopupAnchoredStackView: View {
+    @ObservedObject var viewModel: VM.AnchoredStack
+
+
+    var body: some View { if viewModel.screen.height > 0 {
+        ZStack(alignment: .topLeading, content: createPopupStack)
+            .id(viewModel.popups.isEmpty)
+            .frame(maxWidth: .infinity, maxHeight: viewModel.screen.height)
+    }}
+}
+private extension PopupAnchoredStackView {
+    func createPopupStack() -> some View {
+        ForEach(viewModel.popups, id: \.self, content: createPopup)
+    }
+}
+private extension PopupAnchoredStackView {
+    func createPopup(_ popup: AnyPopup) -> some View {
+        PopupAnchoredContentView(popup: popup, viewModel: viewModel)
+            .opacity(viewModel.calculateOpacity(for: popup))
+    }
+}
+
+// MARK: - Anchored Content View
+/// A wrapper view that measures popup size and positions it correctly
+private struct PopupAnchoredContentView: View {
+    let popup: AnyPopup
+    @ObservedObject var viewModel: VM.AnchoredStack
+    @State private var popupSize: CGSize = .zero
+
+    var body: some View {
+        let position = viewModel.calculatePopupPosition(for: popup, popupSize: popupSize)
+
+        popupContent
+            .background(GeometryReader { geometry in
+                Color.clear.preference(key: SizePreferenceKey.self, value: geometry.size)
+            })
+            .onPreferenceChange(SizePreferenceKey.self) { newSize in
+                if popupSize != newSize {
+                    popupSize = newSize
+                }
+            }
+            .offset(x: position.x, y: position.y)
+            .transition(transition)
+    }
+
+    @ViewBuilder
+    private var popupContent: some View {
+        popup.body
+            .compositingGroup()
+            .fixedSize(horizontal: false, vertical: viewModel.activePopupProperties.verticalFixedSize)
+            .onHeightChange { await viewModel.updatePopupHeight($0, popup) }
+            .background(backgroundColor: popup.config.backgroundColor, overlayColor: .clear, corners: viewModel.activePopupProperties.corners)
+            .focusSection_tvOS()
+    }
+
+    private var transition: AnyTransition {
+        .scale(scale: 0.9, anchor: transitionAnchor).combined(with: .opacity)
+    }
+
+    private var transitionAnchor: UnitPoint {
+        switch popup.config.popupAnchor {
+        case .topLeft: return .topLeading
+        case .top: return .top
+        case .topRight: return .topTrailing
+        case .left: return .leading
+        case .center: return .center
+        case .right: return .trailing
+        case .bottomLeft: return .bottomLeading
+        case .bottom: return .bottom
+        case .bottomRight: return .bottomTrailing
+        }
+    }
+}
+
+// MARK: - Size Preference Key
+private struct SizePreferenceKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        value = nextValue()
+    }
+}

--- a/Sources/Internal/UI/PopupAnchoredStackView.swift
+++ b/Sources/Internal/UI/PopupAnchoredStackView.swift
@@ -139,37 +139,14 @@ private class AnchoredPopupModel: ObservableObject {
 private struct AnchoredPopupContainerView: View {
     @ObservedObject var model: AnchoredPopupModel
 
-    private var shouldShowOverlay: Bool {
-        guard let lastPopup = model.popups.last else { return false }
-        // Show overlay when not pass through (to receive forwarded events from UIKit)
-        return !lastPopup.config.isTapOutsidePassThroughEnabled
-    }
-
     var body: some View {
         // Reference containerSize to trigger re-render when it changes
         let _ = model.containerSize
 
         ZStack(alignment: .topLeading) {
-            // Overlay for handling tap outside (when not pass through)
-            if shouldShowOverlay {
-                Color.clear
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        // Only dismiss if dismiss is enabled
-                        if let lastPopup = model.popups.last,
-                           lastPopup.config.isTapOutsideToDismissEnabled {
-                            Task { @MainActor in
-                                await PopupStack.dismissLastPopup()
-                            }
-                        }
-                        // If dismiss = false, event is consumed but popup stays open
-                    }
-            }
-
             ForEach(model.popups, id: \.self) { popup in
                 let popupId = popup.id.rawValue
                 let frame = model.frame(for: popup)
-
                 PopupContentView(popup: popup, viewModel: model.viewModel, containerSize: model.containerSize)
                     .opacity(frame != nil ? 1 : 0)
                     .sizeReader { size in

--- a/Sources/Internal/UI/PopupAnchoredStackView.swift
+++ b/Sources/Internal/UI/PopupAnchoredStackView.swift
@@ -38,9 +38,9 @@ class AnchoredPopupsContainer: UIView {
                 return true
             }
         }
-        // Outside popup - if not pass through, intercept event
+        // Outside popup - if not passThrough, intercept event
         if let lastPopup = popupModel.popups.last,
-           !lastPopup.config.isTapOutsidePassThroughEnabled {
+           lastPopup.config.tapOutsideBehavior != .passThrough {
             return true
         }
         return false  // pass through
@@ -54,12 +54,12 @@ class AnchoredPopupsContainer: UIView {
                 return hostingController?.view.hitTest(point, with: event)
             }
         }
-        // Outside popup - if not pass through, forward to hosting controller (SwiftUI overlay handles)
+        // Outside popup - if not passThrough, forward to hosting controller (SwiftUI overlay handles)
         if let lastPopup = popupModel.popups.last,
-           !lastPopup.config.isTapOutsidePassThroughEnabled {
+           lastPopup.config.tapOutsideBehavior != .passThrough {
             return hostingController?.view.hitTest(point, with: event)
         }
-        return nil  // pass through to shared overlay
+        return nil  // pass through to underlying views
     }
 
     /// Updates popups in the container

--- a/Sources/Internal/UI/PopupAnchoredStackView.swift
+++ b/Sources/Internal/UI/PopupAnchoredStackView.swift
@@ -38,12 +38,14 @@ class AnchoredPopupsContainer: UIView {
                 return true
             }
         }
-        // Outside popup - if not passThrough, intercept event
+        // Outside popup:
+        // - .none: intercept (block without dismiss)
+        // - .dismiss/.passThrough: pass through to SwiftUI overlay
         if let lastPopup = popupModel.popups.last,
-           lastPopup.config.tapOutsideBehavior != .passThrough {
+           lastPopup.config.tapOutsideBehavior == .none {
             return true
         }
-        return false  // pass through
+        return false
     }
 
     /// Returns hit view for touch handling
@@ -54,12 +56,14 @@ class AnchoredPopupsContainer: UIView {
                 return hostingController?.view.hitTest(point, with: event)
             }
         }
-        // Outside popup - if not passThrough, forward to hosting controller (SwiftUI overlay handles)
+        // Outside popup:
+        // - .none: forward to hosting controller (blocks event)
+        // - .dismiss/.passThrough: return nil to pass through to SwiftUI overlay
         if let lastPopup = popupModel.popups.last,
-           lastPopup.config.tapOutsideBehavior != .passThrough {
+           lastPopup.config.tapOutsideBehavior == .none {
             return hostingController?.view.hitTest(point, with: event)
         }
-        return nil  // pass through to underlying views
+        return nil
     }
 
     /// Updates popups in the container

--- a/Sources/Internal/UI/PopupAnchoredStackView.swift
+++ b/Sources/Internal/UI/PopupAnchoredStackView.swift
@@ -32,7 +32,7 @@ class AnchoredPopupsContainer: UIView {
 
     /// Returns true if touch should be handled by this container
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        // Inside popup frame
+        // Only handle touches inside popup frame
         for popup in popupModel.popups {
             if let frame = popupModel.frame(for: popup), frame.contains(point) {
                 return true

--- a/Sources/Internal/UI/PopupAnchoredStackView.swift
+++ b/Sources/Internal/UI/PopupAnchoredStackView.swift
@@ -196,7 +196,6 @@ private struct PopupContentView: View {
             .environment(\.popupContainerSize, containerSize)
             .compositingGroup()
             .fixedSize(horizontal: false, vertical: viewModel?.activePopupProperties.verticalFixedSize ?? true)
-            .background(backgroundColor: popup.config.backgroundColor, overlayColor: .clear, corners: viewModel?.activePopupProperties.corners ?? [:])
             .opacity(Double(viewModel?.calculateOpacity(for: popup) ?? 1))
     }
 }

--- a/Sources/Internal/UI/PopupView.swift
+++ b/Sources/Internal/UI/PopupView.swift
@@ -142,6 +142,8 @@ private extension PopupView {
     }
     var tapOutsidePassThrough: Bool {
         guard let config = stack.popups.last?.config else { return false }
+        // Only anchored popups support passThrough
+        guard config.alignment == .anchored else { return false }
         return config.tapOutsideBehavior == .passThrough
     }
 }

--- a/Sources/Internal/UI/PopupView.swift
+++ b/Sources/Internal/UI/PopupView.swift
@@ -70,6 +70,7 @@ private extension PopupView {
     func createOverlayView() -> some View {
         getOverlayColor()
             .contentShape(Rectangle())
+            .allowsHitTesting(!tapOutsidePassThrough)
             .zIndex(stack.priority.overlay)
             .animation(.linear, value: stack.popups)
             .onTapGesture(perform: onTap)
@@ -131,4 +132,5 @@ private extension PopupView {
 }
 private extension PopupView {
     var tapOutsideClosesPopup: Bool { stack.popups.last?.config.isTapOutsideToDismissEnabled ?? false }
+    var tapOutsidePassThrough: Bool { stack.popups.last?.config.isTapOutsidePassThroughEnabled ?? false }
 }

--- a/Sources/Internal/UI/PopupView.swift
+++ b/Sources/Internal/UI/PopupView.swift
@@ -131,6 +131,17 @@ private extension PopupView {
     }
 }
 private extension PopupView {
-    var tapOutsideClosesPopup: Bool { stack.popups.last?.config.isTapOutsideToDismissEnabled ?? false }
-    var tapOutsidePassThrough: Bool { stack.popups.last?.config.isTapOutsidePassThroughEnabled ?? false }
+    var tapOutsideClosesPopup: Bool {
+        guard let config = stack.popups.last?.config else { return false }
+        // For anchored popups, use tapOutsideBehavior
+        if config.alignment == .anchored {
+            return config.tapOutsideBehavior == .dismiss
+        }
+        // For other popups, use isTapOutsideToDismissEnabled
+        return config.isTapOutsideToDismissEnabled
+    }
+    var tapOutsidePassThrough: Bool {
+        guard let config = stack.popups.last?.config else { return false }
+        return config.tapOutsideBehavior == .passThrough
+    }
 }

--- a/Sources/Internal/UI/PopupView.swift
+++ b/Sources/Internal/UI/PopupView.swift
@@ -69,6 +69,7 @@ private extension PopupView {
 private extension PopupView {
     func createOverlayView() -> some View {
         getOverlayColor()
+            .contentShape(Rectangle())
             .zIndex(stack.priority.overlay)
             .animation(.linear, value: stack.popups)
             .onTapGesture(perform: onTap)

--- a/Sources/Internal/UI/PopupView.swift
+++ b/Sources/Internal/UI/PopupView.swift
@@ -20,6 +20,7 @@ struct PopupView: View {
     private let topStackViewModel: VM.VerticalStack = .init(TopPopupConfig.self)
     private let centerStackViewModel: VM.CenterStack = .init(CenterPopupConfig.self)
     private let bottomStackViewModel: VM.VerticalStack = .init(BottomPopupConfig.self)
+    private let anchoredStackViewModel: VM.AnchoredStack = .init(AnchoredPopupConfig.self)
 
 
     init(rootView: any View, popupStack: PopupStack) {
@@ -61,6 +62,7 @@ private extension PopupView {
             createTopPopupStackView()
             createCenterPopupStackView()
             createBottomPopupStackView()
+            createAnchoredPopupStackView()
         }
     }
 }
@@ -79,6 +81,9 @@ private extension PopupView {
     }
     func createBottomPopupStackView() -> some View {
         PopupVerticalStackView(viewModel: bottomStackViewModel).zIndex(stack.priority.bottom)
+    }
+    func createAnchoredPopupStackView() -> some View {
+        PopupAnchoredStackView(viewModel: anchoredStackViewModel).zIndex(stack.priority.anchored)
     }
 }
 private extension PopupView {
@@ -119,7 +124,7 @@ private extension PopupView {
         await stack.modify(.removePopup(popup))
     }
     func updateViewModels(_ updateBuilder: @MainActor @escaping (any ViewModel) async -> ()) async {
-        for viewModel in [topStackViewModel, centerStackViewModel, bottomStackViewModel] { await updateBuilder(viewModel as! any ViewModel) }
+        for viewModel in [topStackViewModel, centerStackViewModel, bottomStackViewModel, anchoredStackViewModel] { await updateBuilder(viewModel as! any ViewModel) }
     }
 }
 private extension PopupView {

--- a/Sources/Internal/UI/PopupView.swift
+++ b/Sources/Internal/UI/PopupView.swift
@@ -96,7 +96,8 @@ private extension PopupView {
         await updateViewModels { $0.setup(updatePopupAction: updatePopup, closePopupAction: closePopup) }
     }}
     func onScreenChange(_ screenReader: GeometryProxy) { Task {
-        await updateViewModels { await $0.updateScreen(screenHeight: screenReader.size.height + screenReader.safeAreaInsets.top + screenReader.safeAreaInsets.bottom, screenSafeArea: screenReader.safeAreaInsets) }
+        let screenHeight = screenReader.size.height + screenReader.safeAreaInsets.top + screenReader.safeAreaInsets.bottom
+        await updateViewModels { await $0.updateScreen(screenHeight: screenHeight, screenSafeArea: screenReader.safeAreaInsets) }
     }}
     func onPopupsHeightChange(_ p: Any) { Task {
         await updateViewModels { await $0.updatePopups(stack.popups) }

--- a/Sources/Internal/Utilities/PopupAlignment.swift
+++ b/Sources/Internal/Utilities/PopupAlignment.swift
@@ -15,6 +15,14 @@ enum PopupAlignment {
     case top
     case center
     case bottom
+    case anchored
+}
+
+// MARK: Anchor Point
+public enum PopupAnchorPoint: Sendable {
+    case topLeft, top, topRight
+    case left, center, right
+    case bottomLeft, bottom, bottomRight
 }
 
 // MARK: Initialize
@@ -23,6 +31,7 @@ extension PopupAlignment {
         case is TopPopupConfig.Type: self = .top
         case is CenterPopupConfig.Type: self = .center
         case is BottomPopupConfig.Type: self = .bottom
+        case is AnchoredPopupConfig.Type: self = .anchored
         default: fatalError()
     }}
 }
@@ -33,6 +42,7 @@ extension PopupAlignment {
         case .top: .bottom
         case .center: .center
         case .bottom: .top
+        case .anchored: .anchored
     }}
 }
 
@@ -42,10 +52,12 @@ extension PopupAlignment {
         case .top: .top
         case .center: .bottom
         case .bottom: .bottom
+        case .anchored: .top
     }}
     func toAlignment() -> Alignment { switch self {
         case .top: .top
         case .center: .center
         case .bottom: .bottom
+        case .anchored: .topLeading
     }}
 }

--- a/Sources/Internal/View Models/ViewModel+AnchoredStack.swift
+++ b/Sources/Internal/View Models/ViewModel+AnchoredStack.swift
@@ -94,7 +94,7 @@ extension VM.AnchoredStack {
     /// Calculates the position for the popup based on anchor frame and anchor points
     func calculatePopupPosition(for popup: AnyPopup, popupSize: CGSize, containerSize: CGSize = .zero) -> CGPoint {
         let config = popup.config
-        let anchorFrame = config.anchorFrame
+        let anchorFrame = config.getAnchorFrame()
 
         // Calculate origin point on the anchor view
         let originPoint = calculateAnchorPoint(for: config.originAnchor, in: anchorFrame)

--- a/Sources/Internal/View Models/ViewModel+AnchoredStack.swift
+++ b/Sources/Internal/View Models/ViewModel+AnchoredStack.swift
@@ -1,0 +1,143 @@
+//
+//  ViewModel+AnchoredStack.swift of MijickPopups
+//
+//  Created by Vidy. Extending MijickPopups with anchored popup support.
+//
+//  Copyright 2024 Mijick. All rights reserved.
+
+
+import SwiftUI
+
+extension VM { class AnchoredStack: ViewModel { required init() {}
+    var alignment: PopupAlignment = .anchored
+    var popups: [AnyPopup] = []
+    var activePopupProperties: ActivePopupProperties = .init()
+    var screen: Screen = .init()
+    var updatePopupAction: ((AnyPopup) async -> ())?
+    var closePopupAction: ((AnyPopup) async -> ())?
+}}
+
+
+// MARK: - METHODS / VIEW MODEL / ACTIVE POPUP
+
+
+
+// MARK: Height
+extension VM.AnchoredStack {
+    func calculateActivePopupHeight() async -> CGFloat? {
+        popups.last?.height
+    }
+}
+
+// MARK: Outer Padding
+extension VM.AnchoredStack {
+    func calculateActivePopupOuterPadding() async -> EdgeInsets { .init() }
+}
+
+// MARK: Inner Padding
+extension VM.AnchoredStack {
+    func calculateActivePopupInnerPadding() async -> EdgeInsets { .init() }
+}
+
+// MARK: Corners
+extension VM.AnchoredStack {
+    func calculateActivePopupCorners() async -> [PopupAlignment : CGFloat] { [
+        .top: popups.last?.config.cornerRadius ?? 0,
+        .bottom: popups.last?.config.cornerRadius ?? 0
+    ]}
+}
+
+// MARK: Vertical Fixed Size
+extension VM.AnchoredStack {
+    func calculateActivePopupVerticalFixedSize() async -> Bool { true }
+}
+
+// MARK: Translation Progress
+extension VM.AnchoredStack {
+    func calculateActivePopupTranslationProgress() async -> CGFloat { 0 }
+}
+
+
+// MARK: - METHODS / VIEW MODEL / SELECTED POPUP
+
+
+
+// MARK: Height
+extension VM.AnchoredStack {
+    func calculatePopupHeight(_ heightCandidate: CGFloat, _ popup: AnyPopup) async -> CGFloat {
+        min(heightCandidate, calculateMaxHeight())
+    }
+}
+private extension VM.AnchoredStack {
+    func calculateMaxHeight() -> CGFloat {
+        let fullscreenHeight = screen.height,
+            safeAreaHeight = screen.safeArea.top + screen.safeArea.bottom
+        return fullscreenHeight - safeAreaHeight
+    }
+}
+
+
+// MARK: - METHODS / VIEW
+
+
+
+// MARK: Opacity
+extension VM.AnchoredStack {
+    func calculateOpacity(for popup: AnyPopup) -> CGFloat {
+        popups.last == popup ? 1 : 0
+    }
+}
+
+// MARK: Position Calculation
+extension VM.AnchoredStack {
+    /// Calculates the position for the popup based on anchor frame and anchor points
+    func calculatePopupPosition(for popup: AnyPopup, popupSize: CGSize) -> CGPoint {
+        let config = popup.config
+        let anchorFrame = config.anchorFrame
+
+        // Calculate origin point on the anchor view
+        let originPoint = calculateAnchorPoint(for: config.originAnchor, in: anchorFrame)
+
+        // Calculate the offset needed based on popup anchor point
+        let popupOffset = calculatePopupOffset(for: config.popupAnchor, popupSize: popupSize)
+
+        // Final position = origin point - popup offset + user offset
+        return CGPoint(
+            x: originPoint.x - popupOffset.x + config.anchorOffset.x,
+            y: originPoint.y - popupOffset.y + config.anchorOffset.y
+        )
+    }
+
+    /// Calculates a point on the anchor frame based on the anchor point type
+    private func calculateAnchorPoint(for anchor: PopupAnchorPoint, in frame: CGRect) -> CGPoint {
+        switch anchor {
+        case .topLeft:     return CGPoint(x: frame.minX, y: frame.minY)
+        case .top:         return CGPoint(x: frame.midX, y: frame.minY)
+        case .topRight:    return CGPoint(x: frame.maxX, y: frame.minY)
+        case .left:        return CGPoint(x: frame.minX, y: frame.midY)
+        case .center:      return CGPoint(x: frame.midX, y: frame.midY)
+        case .right:       return CGPoint(x: frame.maxX, y: frame.midY)
+        case .bottomLeft:  return CGPoint(x: frame.minX, y: frame.maxY)
+        case .bottom:      return CGPoint(x: frame.midX, y: frame.maxY)
+        case .bottomRight: return CGPoint(x: frame.maxX, y: frame.maxY)
+        }
+    }
+
+    /// Calculates the offset within the popup based on its anchor point
+    private func calculatePopupOffset(for anchor: PopupAnchorPoint, popupSize: CGSize) -> CGPoint {
+        let width = popupSize.width
+        let height = popupSize.height
+
+        switch anchor {
+        case .topLeft:     return CGPoint(x: 0, y: 0)
+        case .top:         return CGPoint(x: width / 2, y: 0)
+        case .topRight:    return CGPoint(x: width, y: 0)
+        case .left:        return CGPoint(x: 0, y: height / 2)
+        case .center:      return CGPoint(x: width / 2, y: height / 2)
+        case .right:       return CGPoint(x: width, y: height / 2)
+        case .bottomLeft:  return CGPoint(x: 0, y: height)
+        case .bottom:      return CGPoint(x: width / 2, y: height)
+        case .bottomRight: return CGPoint(x: width, y: height)
+        }
+    }
+}

--- a/Sources/Internal/View Models/ViewModel+AnchoredStack.swift
+++ b/Sources/Internal/View Models/ViewModel+AnchoredStack.swift
@@ -84,7 +84,8 @@ private extension VM.AnchoredStack {
 // MARK: Opacity
 extension VM.AnchoredStack {
     func calculateOpacity(for popup: AnyPopup) -> CGFloat {
-        popups.last == popup ? 1 : 0
+        // AnchoredPopup supports multiple popups displayed simultaneously, so all popups have opacity 1
+        1
     }
 }
 

--- a/Sources/Internal/View Models/ViewModel+VerticalStack.swift
+++ b/Sources/Internal/View Models/ViewModel+VerticalStack.swift
@@ -40,7 +40,7 @@ private extension VM.VerticalStack {
     func getDragTranslationMultiplier() -> CGFloat { switch alignment {
         case .top: 1
         case .bottom: -1
-        case .center: fatalError()
+        case .center, .anchored: fatalError()
     }}
 }
 
@@ -93,7 +93,7 @@ private extension VM.VerticalStack {
         return switch alignment {
             case .top: calculateVerticalInnerPaddingAdhereEdge(safeAreaHeight: screen.safeArea.top, popupOuterPadding: activePopupProperties.outerPadding.top)
             case .bottom: calculateVerticalInnerPaddingCounterEdge(popupHeight: activePopupProperties.height ?? 0, safeArea: screen.safeArea.top)
-            case .center: fatalError()
+            case .center, .anchored: fatalError()
         }
     }
     func calculateBottomInnerPadding(popup: AnyPopup) -> CGFloat {
@@ -102,7 +102,7 @@ private extension VM.VerticalStack {
         return switch alignment {
             case .top: calculateVerticalInnerPaddingCounterEdge(popupHeight: activePopupProperties.height ?? 0, safeArea: screen.safeArea.bottom)
             case .bottom: calculateVerticalInnerPaddingAdhereEdge(safeAreaHeight: screen.safeArea.bottom, popupOuterPadding: activePopupProperties.outerPadding.bottom)
-            case .center: fatalError()
+            case .center, .anchored: fatalError()
         }
     }
     func calculateLeadingInnerPadding(popup: AnyPopup) -> CGFloat { switch popup.config.ignoredSafeAreaEdges.contains(.leading) {
@@ -143,12 +143,12 @@ private extension VM.VerticalStack {
     func calculateTopCornerRadius(_ cornerRadiusValue: CGFloat) -> CGFloat { switch alignment {
         case .top: activePopupProperties.outerPadding.top != 0 ? cornerRadiusValue : 0
         case .bottom: cornerRadiusValue
-        case .center: fatalError()
+        case .center, .anchored: fatalError()
     }}
     func calculateBottomCornerRadius(_ cornerRadiusValue: CGFloat) -> CGFloat { switch alignment {
         case .top: cornerRadiusValue
         case .bottom: activePopupProperties.outerPadding.bottom != 0 ? cornerRadiusValue : 0
-        case .center: fatalError()
+        case .center, .anchored: fatalError()
     }}
 }
 
@@ -165,7 +165,7 @@ extension VM.VerticalStack {
     func calculateActivePopupTranslationProgress() async -> CGFloat { guard let activePopupHeight = popups.last?.height else { return 0 }; return switch alignment {
         case .top: abs(min(activePopupProperties.gestureTranslation + (popups.last?.dragHeight ?? 0), 0)) / activePopupHeight
         case .bottom: max(activePopupProperties.gestureTranslation - (popups.last?.dragHeight ?? 0), 0) / activePopupHeight
-        case .center: fatalError()
+        case .center, .anchored: fatalError()
     }}
 }
 
@@ -237,7 +237,7 @@ private extension VM.VerticalStack {
         return switch alignment {
             case .top: min(activePopupProperties.gestureTranslation + lastPopupDragHeight, 0)
             case .bottom: max(activePopupProperties.gestureTranslation - lastPopupDragHeight, 0)
-            case .center: fatalError()
+            case .center, .anchored: fatalError()
         }
     }
     func calculateOffsetForStackedPopup(_ popup: AnyPopup) -> CGFloat {
@@ -246,7 +246,7 @@ private extension VM.VerticalStack {
         let alignmentMultiplier = switch alignment {
             case .top: 1.0
             case .bottom: -1.0
-            case .center: fatalError()
+            case .center, .anchored: fatalError()
         }
 
         return offsetValue * alignmentMultiplier
@@ -364,7 +364,7 @@ private extension VM.VerticalStack {
     func calculateDragExtremeValue(_ value1: CGFloat, _ value2: CGFloat) -> CGFloat { switch alignment {
         case .top: min(value1, value2)
         case .bottom: max(value1, value2)
-        case .center: fatalError()
+        case .center, .anchored: fatalError()
     }}
 }
 

--- a/Sources/Public/Dismiss/Public+Dismiss+PopupStack.swift
+++ b/Sources/Public/Dismiss/Public+Dismiss+PopupStack.swift
@@ -54,4 +54,15 @@ public extension PopupStack {
      - Important: Make sure you use the correct **popupStackID** from which you want to remove the popups.
      */
     @MainActor static func dismissAllPopups(popupStackID: PopupStackID = .shared) async { await fetch(id: popupStackID)?.modify(.removeAllPopups) }
+
+    /**
+     Dismisses all the popups except those with the specified identifiers.
+
+     - Parameters:
+        - ids: Identifiers of the popups to keep on the stack.
+        - popupStackID: The identifier for which the popup was presented. For more information, see ``Popup/present(popupStackID:)``.
+
+     - Important: Make sure you use the correct **popupStackID** from which you want to remove the popups.
+     */
+    @MainActor static func dismissAllPopups(excluding ids: [String], popupStackID: PopupStackID = .shared) async { await fetch(id: popupStackID)?.modify(.removeAllPopupsExcluding(ids)) }
 }

--- a/Sources/Public/Dismiss/Public+Dismiss+View.swift
+++ b/Sources/Public/Dismiss/Public+Dismiss+View.swift
@@ -54,4 +54,15 @@ public extension View {
      - Important: Make sure you use the correct **popupStackID** from which you want to remove the popups.
      */
     @MainActor func dismissAllPopups(popupStackID: PopupStackID = .shared) async { await PopupStack.dismissAllPopups(popupStackID: popupStackID) }
+
+    /**
+     Dismisses all the popups except those with the specified identifiers.
+
+     - Parameters:
+        - ids: Identifiers of the popups to keep on the stack.
+        - popupStackID: The identifier for which the popup was presented. For more information, see ``Popup/present(popupStackID:)``.
+
+     - Important: Make sure you use the correct **popupStackID** from which you want to remove the popups.
+     */
+    @MainActor func dismissAllPopups(excluding ids: [String], popupStackID: PopupStackID = .shared) async { await PopupStack.dismissAllPopups(excluding: ids, popupStackID: popupStackID) }
 }

--- a/Sources/Public/Popup/Public+Popup+Config.swift
+++ b/Sources/Public/Popup/Public+Popup+Config.swift
@@ -153,12 +153,30 @@ public extension LocalConfigVertical {
     
     /**
      Defines the vertical size (in points) of the area that responds to dismissal drag gesture.
-     
-     Use this to control how much of the popup’s top/bottom region is draggable for dismiss gesture.
+
+     Use this to control how much of the popup's top/bottom region is draggable for dismiss gesture.
      A larger value allows dragging from a wider area.
-     
+
      ## Visualisation
      ![image](https://github.com/Mijick/Assets/blob/main/Framework%20Docs/Popups/bottom-popup-draggable-area.png?raw=true)
      */
     func dragGestureAreaSize(_ value: CGFloat) -> Self { self.dragGestureAreaSize = value; return self }
+}
+
+// MARK: Anchored
+public extension LocalConfigAnchored {
+    /// Distance of the popup from its edges.
+    func popupPadding(_ value: EdgeInsets) -> Self { self.popupPadding = value; return self }
+
+    /// Corner radius of the background of the active popup.
+    func cornerRadius(_ value: CGFloat) -> Self { self.cornerRadius = value; return self }
+
+    /// Background color of the popup.
+    func backgroundColor(_ color: Color) -> Self { self.backgroundColor = color; return self }
+
+    /// The color of the overlay covering the view behind the popup.
+    func overlayColor(_ color: Color) -> Self { self.overlayColor = color; return self }
+
+    /// If enabled, dismisses the active popup when touched outside its area.
+    func tapOutsideToDismissPopup(_ value: Bool) -> Self { self.isTapOutsideToDismissEnabled = value; return self }
 }

--- a/Sources/Public/Popup/Public+Popup+Config.swift
+++ b/Sources/Public/Popup/Public+Popup+Config.swift
@@ -170,7 +170,4 @@ public extension LocalConfigAnchored {
 
     /// The color of the overlay covering the view behind the popup.
     func overlayColor(_ color: Color) -> Self { self.overlayColor = color; return self }
-
-    /// If enabled, dismisses the active popup when touched outside its area.
-    func tapOutsideToDismissPopup(_ value: Bool) -> Self { self.isTapOutsideToDismissEnabled = value; return self }
 }

--- a/Sources/Public/Popup/Public+Popup+Config.swift
+++ b/Sources/Public/Popup/Public+Popup+Config.swift
@@ -168,12 +168,6 @@ public extension LocalConfigAnchored {
     /// Distance of the popup from its edges.
     func popupPadding(_ value: EdgeInsets) -> Self { self.popupPadding = value; return self }
 
-    /// Corner radius of the background of the active popup.
-    func cornerRadius(_ value: CGFloat) -> Self { self.cornerRadius = value; return self }
-
-    /// Background color of the popup.
-    func backgroundColor(_ color: Color) -> Self { self.backgroundColor = color; return self }
-
     /// The color of the overlay covering the view behind the popup.
     func overlayColor(_ color: Color) -> Self { self.overlayColor = color; return self }
 

--- a/Sources/Public/Popup/Public+Popup+Main.swift
+++ b/Sources/Public/Popup/Public+Popup+Main.swift
@@ -130,3 +130,35 @@ public typealias CenterPopupConfig = LocalConfigCenter
  */
 public protocol BottomPopup: Popup { associatedtype Config = BottomPopupConfig }
 public typealias BottomPopupConfig = LocalConfigVertical.Bottom
+
+/**
+ The view to be displayed as an Anchored popup, positioned relative to a source view.
+
+ ## Optional Methods
+ - ``Popup/configurePopup(config:)-98ha0``
+ - ``Popup/onFocus()-loq5``
+ - ``Popup/onDismiss()-254h8``
+
+ ## Usage
+ ```swift
+ struct AnchoredPopupExample: AnchoredPopup {
+    func onFocus() { print("Popup is now active") }
+    func onDismiss() { print("Popup was dismissed") }
+    func configurePopup(config: AnchoredPopupConfig) -> AnchoredPopupConfig { config
+        .originAnchor(.bottom)
+        .popupAnchor(.top)
+        .offset(x: 0, y: 8)
+        .cornerRadius(12)
+    }
+    var body: some View {
+        Text("Hello Kitty")
+    }
+ }
+
+ // Present with anchor frame
+ Button("Show") {
+     Task { await AnchoredPopupExample().present(anchoredTo: buttonFrame) }
+ }
+ ```
+ */
+public protocol AnchoredPopup: Popup { associatedtype Config = AnchoredPopupConfig }

--- a/Sources/Public/Present/Public+Present+Popup.swift
+++ b/Sources/Public/Present/Public+Present+Popup.swift
@@ -29,10 +29,39 @@ public extension Popup {
      ``SwiftUICore/View/dismissPopup(_:popupStackID:)-9mkd5``,
      ``SwiftUICore/View/dismissAllPopups(popupStackID:)``
      should be called with the same **popupStackID** as the one used here.
-     
+
      - Warning: To present multiple popups of the same type, set a unique identifier using the method ``Popup/setCustomID(_:)``.
      */
     @MainActor func present(popupStackID: PopupStackID = .shared) async { await PopupStack.fetch(id: popupStackID)?.modify(.insertPopup(.init(self))) }
+}
+
+// MARK: Anchored Popup Present
+public extension AnchoredPopup {
+    /**
+     Presents the anchored popup positioned relative to a source view frame.
+
+     - Parameters:
+        - anchorFrame: The frame of the source view to anchor the popup to (in global coordinates).
+        - popupStackID: The identifier registered in one of the application windows in which the popup is to be displayed.
+
+     - Important: The **anchorFrame** should be in global screen coordinates. Use `.frameReader` or `GeometryReader` to obtain the frame.
+
+     ## Usage
+     ```swift
+     @State private var buttonFrame: CGRect = .zero
+
+     Button("Show") {
+         Task { await MyAnchoredPopup().present(anchoredTo: buttonFrame) }
+     }
+     .frameReader { frame in
+         buttonFrame = frame
+     }
+     ```
+     */
+    @MainActor func present(anchoredTo anchorFrame: CGRect, popupStackID: PopupStackID = .shared) async {
+        let popup = await AnyPopup(self).updatedAnchorFrame(anchorFrame)
+        await PopupStack.fetch(id: popupStackID)?.modify(.insertPopup(popup))
+    }
 }
 
 // MARK: Configure Popup

--- a/Sources/Public/Present/Public+Present+Popup.swift
+++ b/Sources/Public/Present/Public+Present+Popup.swift
@@ -58,8 +58,12 @@ public extension AnchoredPopup {
      }
      ```
      */
-    @MainActor func present(anchoredTo anchorFrame: CGRect, popupStackID: PopupStackID = .shared) async {
-        let popup = await AnyPopup(self).updatedAnchorFrame(anchorFrame)
+    @MainActor func present(anchoredTo anchorFrame: CGRect, customID: String? = nil, popupStackID: PopupStackID = .shared) async {
+        var popup = await AnyPopup(self)
+        if let customID = customID {
+            popup = await popup.updatedID(customID)
+        }
+        popup = popup.updatedAnchorFrame(anchorFrame)
         await PopupStack.fetch(id: popupStackID)?.modify(.insertPopup(popup))
     }
 }

--- a/Sources/Public/Present/Public+Present+Popup.swift
+++ b/Sources/Public/Present/Public+Present+Popup.swift
@@ -38,35 +38,66 @@ public extension Popup {
 // MARK: Anchored Popup Present
 public extension AnchoredPopup {
     /**
-     Presents the anchored popup positioned relative to a source view frame.
+     Presents the anchored popup positioned relative to a tracked anchor view.
+
+     Use this with `.trackAnchor(_:)` modifier to track the source view's frame.
 
      - Parameters:
-        - anchorFrameProvider: A closure that returns the frame of the source view (in global coordinates).
-          The closure is called each time the popup position needs to be recalculated.
-        - customID: Optional custom identifier for the popup.
-        - popupStackID: The identifier registered in one of the application windows in which the popup is to be displayed.
-
-     - Important: The frame returned by **anchorFrameProvider** should be in global screen coordinates.
-       Use `.frameReader` or `GeometryReader` to obtain the frame.
+        - anchorID: The ID used in `.trackAnchor(_:)` on the source view.
+        - customID: Optional custom identifier for the popup (for dismiss management). Defaults to anchorID.
+        - popupStackID: The identifier registered in one of the application windows.
 
      ## Usage
      ```swift
-     @State private var buttonFrame: CGRect = .zero
+     // Track the button
+     Button("Pen") { ... }
+         .trackAnchor("pen")
 
-     Button("Show") {
-         Task { await MyAnchoredPopup().present(anchoredTo: { buttonFrame }) }
-     }
-     .frameReader { frame in
-         buttonFrame = frame
-     }
+     // Present popup anchored to it
+     MyPopup().present(anchoredTo: "pen")
+
+     // With custom ID for dismiss management
+     MyPopup().present(anchoredTo: "pen", customID: "penPopup")
      ```
      */
-    @MainActor func present(anchoredTo anchorFrameProvider: @escaping () -> CGRect, customID: String? = nil, popupStackID: PopupStackID = .shared) async {
+    @MainActor func present(
+        anchoredTo anchorID: String,
+        customID: String? = nil,
+        popupStackID: PopupStackID = .shared
+    ) async {
+        var popup = await AnyPopup(self)
+        // Use customID if provided, otherwise default to anchorID
+        popup = await popup.updatedID(customID ?? anchorID)
+        popup = popup.updatedAnchorID(anchorID)
+        await PopupStack.fetch(id: popupStackID)?.modify(.insertPopup(popup))
+        makePopupWindowKey()
+    }
+
+    /**
+     Presents the anchored popup positioned relative to a static anchor frame.
+
+     Use this for dynamic scenarios where you have a computed frame (e.g., list items).
+
+     - Parameters:
+        - anchorFrame: The frame of the anchor view in global coordinates.
+        - customID: Optional custom identifier for the popup (for dismiss management).
+        - popupStackID: The identifier registered in one of the application windows.
+
+     ## Usage
+     ```swift
+     MyPopup().present(anchoredTo: buttonFrame, customID: "menu")
+     ```
+     */
+    @MainActor func present(
+        anchoredTo anchorFrame: CGRect,
+        customID: String? = nil,
+        popupStackID: PopupStackID = .shared
+    ) async {
         var popup = await AnyPopup(self)
         if let customID = customID {
             popup = await popup.updatedID(customID)
         }
-        popup = popup.updatedAnchorFrameProvider(anchorFrameProvider)
+        popup = popup.updatedAnchorFrame(anchorFrame)
         await PopupStack.fetch(id: popupStackID)?.modify(.insertPopup(popup))
     }
 }

--- a/Sources/Public/Setup/AnchorRegistry.swift
+++ b/Sources/Public/Setup/AnchorRegistry.swift
@@ -1,0 +1,31 @@
+//
+//  AnchorRegistry.swift of MijickPopups
+//
+//  Created by Vidy. Global anchor frame registry for anchored popups.
+//
+//  Copyright 2024 Mijick. All rights reserved.
+
+
+import SwiftUI
+
+/// Global registry for anchor frames, keyed by string ID.
+/// Used internally by `trackAnchor(_:)` and `present(anchoredTo:)`.
+@MainActor
+public enum AnchorRegistry {
+    private static var frames: [String: CGRect] = [:]
+
+    /// Register or update an anchor frame
+    public static func setFrame(_ frame: CGRect, forKey key: String) {
+        frames[key] = frame
+    }
+
+    /// Get anchor frame by key
+    public static func frame(forKey key: String) -> CGRect {
+        frames[key] ?? .zero
+    }
+
+    /// Remove anchor frame
+    public static func removeFrame(forKey key: String) {
+        frames.removeValue(forKey: key)
+    }
+}

--- a/Sources/Public/Setup/Public+PopupContainerSize.swift
+++ b/Sources/Public/Setup/Public+PopupContainerSize.swift
@@ -1,0 +1,23 @@
+//
+//  Public+PopupContainerSize.swift of MijickPopups
+//
+//  Created by Vidy. Exposing container size to popup content.
+//
+//  Copyright 2024 Mijick. All rights reserved.
+
+import SwiftUI
+
+// MARK: - Environment Key
+
+private struct PopupContainerSizeKey: EnvironmentKey {
+    static let defaultValue: CGSize = .zero
+}
+
+public extension EnvironmentValues {
+    /// The size of the popup container (window size).
+    /// Available in AnchoredPopup body, updates when window resizes.
+    var popupContainerSize: CGSize {
+        get { self[PopupContainerSizeKey.self] }
+        set { self[PopupContainerSizeKey.self] = newValue }
+    }
+}

--- a/Sources/Public/Setup/Public+Setup+SceneDelegate.swift
+++ b/Sources/Public/Setup/Public+Setup+SceneDelegate.swift
@@ -155,7 +155,7 @@ private extension Window {
 
         // Touch outside AnchoredPopup - check if pass-through is enabled
         if let lastAnchored = anchoredPopups.last,
-           lastAnchored.config.isTapOutsidePassThroughEnabled {
+           lastAnchored.config.tapOutsideBehavior == .passThrough {
             return .passThrough
         }
         return .block

--- a/Sources/Public/Setup/Public+Setup+SceneDelegate.swift
+++ b/Sources/Public/Setup/Public+Setup+SceneDelegate.swift
@@ -161,16 +161,25 @@ private extension Window {
         return .block
     }
 
+    /// Check if there are non-anchored popups (BottomPopup, CenterPopup, etc.)
+    func hasNonAnchoredPopups() -> Bool {
+        let nonAnchoredPopups = PopupStackContainer.stacks.first?.popups.filter { $0.config.alignment != .anchored } ?? []
+        return !nonAnchoredPopups.isEmpty
+    }
+
     @available(iOS 26, *)
     func hitTest_iOS26(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         switch handleAnchoredPopupHitTest(point, with: event) {
         case .hit(let view): return view
-        case .passThrough: return nil
+        case .passThrough:
+            // If no other popups, pass through to app
+            if !hasNonAnchoredPopups() { return nil }
+            // Otherwise continue to check other popups
         case .block: return rootViewController?.view
         case .noAnchoredPopup: break
         }
 
-        // No AnchoredPopup displayed, use original logic (for BottomPopup, CenterPopup, etc.)
+        // Check other popups (BottomPopup, CenterPopup, etc.)
         guard let rootView = rootViewController?.view else { return nil }
         guard PopupStackContainer.stacks.first?.popups.last != nil else { return nil }
 
@@ -188,7 +197,10 @@ private extension Window {
     func hitTest_iOS18(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         switch handleAnchoredPopupHitTest(point, with: event) {
         case .hit(let view): return view
-        case .passThrough: return nil
+        case .passThrough:
+            // If no other popups, pass through to app
+            if !hasNonAnchoredPopups() { return nil }
+            // Otherwise continue to check other popups
         case .block: return rootViewController?.view
         case .noAnchoredPopup: break
         }
@@ -200,7 +212,10 @@ private extension Window {
     func hitTest_iOS17(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         switch handleAnchoredPopupHitTest(point, with: event) {
         case .hit(let view): return view
-        case .passThrough: return nil
+        case .passThrough:
+            // If no other popups, pass through to app
+            if !hasNonAnchoredPopups() { return nil }
+            // Otherwise continue to check other popups
         case .block: return rootViewController?.view
         case .noAnchoredPopup: break
         }

--- a/Sources/Public/Setup/Public+Setup+SceneDelegate.swift
+++ b/Sources/Public/Setup/Public+Setup+SceneDelegate.swift
@@ -138,7 +138,13 @@ private extension Window {
     }
 
     func handleAnchoredPopupHitTest(_ point: CGPoint, with event: UIEvent?) -> AnchoredHitTestResult {
-        guard let container = AnchoredPopupsContainer.shared, !container.subviews.isEmpty else {
+        // Check if there are any anchored popups displayed
+        let anchoredPopups = PopupStackContainer.stacks.first?.popups.filter { $0.config.alignment == .anchored } ?? []
+        guard !anchoredPopups.isEmpty else {
+            return .noAnchoredPopup
+        }
+
+        guard let container = AnchoredPopupsContainer.shared else {
             return .noAnchoredPopup
         }
 
@@ -148,8 +154,7 @@ private extension Window {
         }
 
         // Touch outside AnchoredPopup - check if pass-through is enabled
-        let anchoredPopups = PopupStackContainer.stacks.first?.popups.filter { $0.config.alignment == .anchored }
-        if let lastAnchored = anchoredPopups?.last,
+        if let lastAnchored = anchoredPopups.last,
            lastAnchored.config.isTapOutsidePassThroughEnabled {
             return .passThrough
         }

--- a/Sources/Public/Setup/View+TrackAnchor.swift
+++ b/Sources/Public/Setup/View+TrackAnchor.swift
@@ -1,0 +1,42 @@
+//
+//  View+TrackAnchor.swift of MijickPopups
+//
+//  Created by Vidy. Track view frames for anchored popups.
+//
+//  Copyright 2024 Mijick. All rights reserved.
+
+
+import SwiftUI
+
+public extension View {
+    /// Tracks this view's global frame in the anchor registry.
+    /// Use this with `present(anchoredTo:)` to anchor popups to this view.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// Button("Show Popup") { ... }
+    ///     .trackAnchor("myButton")
+    ///
+    /// // Then present popup anchored to this button
+    /// MyPopup().present(anchoredTo: "myButton")
+    /// ```
+    ///
+    /// - Parameter id: A unique identifier for this anchor. Use the same ID in `present(anchoredTo:)`.
+    /// - Returns: A view that tracks its frame in the global anchor registry.
+    func trackAnchor(_ id: String) -> some View {
+        self.background(
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear {
+                        AnchorRegistry.setFrame(geo.frame(in: .global), forKey: id)
+                    }
+                    .onChange(of: geo.frame(in: .global)) { newFrame in
+                        AnchorRegistry.setFrame(newFrame, forKey: id)
+                    }
+                    .onDisappear {
+                        AnchorRegistry.removeFrame(forKey: id)
+                    }
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Add AnchoredPopup protocol and configuration for absolute positioning of popups, allowing popups to be anchored to specific screen coordinates.

Closes #197

## Changes
- Add `PopupAlignment.anchored` case
- Create `AnchoredPopup` protocol and `AnchoredPopupConfig`
- Implement `present(anchoredTo:)` API for specifying anchor frame
- Create `PopupAnchoredStackView` for rendering anchored popups
- Support `originAnchor`/`popupAnchor` configuration for flexible positioning
- Add `PopupAnchorPoint` enum with 9 anchor positions

## Usage
```swift
struct MyAnchoredPopup: AnchoredPopup {
    var body: some View {
        Text("Anchored content")
    }
    
    func configurePopup(config: AnchoredPopupConfig) -> AnchoredPopupConfig {
        config
            .originAnchor(.bottom)
            .popupAnchor(.top)
    }
}

// Present anchored to a specific frame
await MyAnchoredPopup().present(anchoredTo: buttonFrame)

```

## AnchoredPopup Compatibility Limitations

  AnchoredPopup is iOS/iPadOS only. Not available on macOS, tvOS, or watchOS.

  Why This Limitation Exists

  Core Reason: Touch Pass-Through Requires UIKit

  AnchoredPopup's key feature is allowing touches outside the popup to pass through to underlying views. This requires:

  | Feature                         | UIKit Implementation | SwiftUI Alternative         |
  |---------------------------------|----------------------|-----------------------------|
  | Intercept touch events          | point(inside:with:)  | ❌ None                      |
  | Forward touches to layers below | hitTest(_:with:)     | ❌ None                      |
  | Independent window layer        | UIWindow subclass    | ❌ No precise control        |
  | Access window reference         | UIViewRepresentable  | NSViewRepresentable (macOS) |

  Why Pure SwiftUI Won't Work

  Popup Layer (Popup Window)
      ↓ tap outside
  Main View Layer (App Window)  ← needs to receive event

  SwiftUI's overlay / ZStack cannot:
  - Intercept events in one area (inside popup)
  - Pass through events in another area (outside popup)

  UIKit's hitTest override enables precise per-point event routing.

  Design Trade-offs

  UIKit implementation was chosen for:
  1. Feature completeness - Touch pass-through is essential for anchored popups in my case
  2. Primary platform - iOS/iPadOS is the main target
  3. UX requirements - Users need to interact with content beneath the popup without dismissing it

  Future Options

  | Approach                          | Effort | Result                |
  |-----------------------------------|--------|-----------------------|
  | Conditional compilation (disable) | Low    | No macOS support      |
  | Pure SwiftUI (simplified)         | Medium | No touch pass-through |
  | AppKit native implementation      | High   | Full functionality    |