### PR TITLE
feat: Allow custom transition animation for popups

### DIFF
--- a/Sources/Internal/Configurables/Local/LocalConfig+Vertical.swift
+++ b/Sources/Internal/Configurables/Local/LocalConfig+Vertical.swift
@@ -26,6 +26,9 @@ public class LocalConfigVertical: LocalConfig { required public init() {}
     public var isTapOutsideToDismissEnabled: Bool = GlobalConfigContainer.vertical.isTapOutsideToDismissEnabled
     public var isDragGestureEnabled: Bool = GlobalConfigContainer.vertical.isDragGestureEnabled
     public var dragGestureAreaSize: CGFloat = GlobalConfigContainer.vertical.dragGestureAreaSize
+
+    // MARK: Transition
+    public var transition: AnyTransition? = nil
 }
 
 // MARK: Subclasses

--- a/Sources/Internal/Models/AnyPopupConfig.swift
+++ b/Sources/Internal/Models/AnyPopupConfig.swift
@@ -26,6 +26,9 @@ struct AnyPopupConfig: LocalConfig, Sendable { init() {}
     var isTapOutsideToDismissEnabled: Bool = false
     var isDragGestureEnabled: Bool = false
     var dragGestureAreaSize: CGFloat = 0
+
+    // MARK: Transition
+    var transition: AnyTransition? = nil
 }
 
 // MARK: Initialize
@@ -42,5 +45,10 @@ extension AnyPopupConfig {
         self.isTapOutsideToDismissEnabled = config.isTapOutsideToDismissEnabled
         self.isDragGestureEnabled = config.isDragGestureEnabled
         self.dragGestureAreaSize = config.dragGestureAreaSize
+
+        // Vertical-specific properties (transition)
+        if let verticalConfig = config as? LocalConfigVertical {
+            self.transition = verticalConfig.transition
+        }
     }
 }

--- a/Sources/Internal/UI/PopupVerticalStackView.swift
+++ b/Sources/Internal/UI/PopupVerticalStackView.swift
@@ -39,7 +39,7 @@ private extension PopupVerticalStackView {
             .scaleEffect(x: viewModel.calculateScaleX(for: popup))
             .focusSection_tvOS()
             .padding(viewModel.activePopupProperties.outerPadding)
-            .transition(transition)
+            .transition(getTransition(for: popup))
             .zIndex(viewModel.calculateZIndex())
             .onDragGesture(onChanged: viewModel.onPopupDragGestureChanged, onEnded: viewModel.onPopupDragGestureEnded, isEnabled: viewModel.dragGestureEnabled)
     }}
@@ -48,9 +48,10 @@ private extension PopupVerticalStackView {
 private extension PopupVerticalStackView {
     func getBackgroundColor(for popup: AnyPopup) -> Color { popup.config.backgroundColor }
     func getStackOverlayColor(for popup: AnyPopup) -> Color { stackOverlayColor.opacity(viewModel.calculateStackOverlayOpacity(for: popup)) }
+    func getTransition(for popup: AnyPopup) -> AnyTransition { popup.config.transition ?? defaultTransition }
 }
 private extension PopupVerticalStackView {
     var stackOverlayColor: Color { .black }
-    var transition: AnyTransition { .move(edge: viewModel.alignment.toEdge()) }
+    var defaultTransition: AnyTransition { .move(edge: viewModel.alignment.toEdge()) }
     var popupAlignment: Alignment { (!viewModel.alignment).toAlignment() }
 }

--- a/Sources/Public/Popup/Public+Popup+Config.swift
+++ b/Sources/Public/Popup/Public+Popup+Config.swift
@@ -161,4 +161,19 @@ public extension LocalConfigVertical {
      ![image](https://github.com/Mijick/Assets/blob/main/Framework%20Docs/Popups/bottom-popup-draggable-area.png?raw=true)
      */
     func dragGestureAreaSize(_ value: CGFloat) -> Self { self.dragGestureAreaSize = value; return self }
+
+    /**
+     Sets a custom transition animation for the popup.
+
+     By default, vertical popups use `.move(edge:)` transition.
+     Use this to override with a custom transition like `.opacity`, `.scale`, or a combination.
+
+     ## Example
+     ```swift
+     func configurePopup(config: BottomPopupConfig) -> BottomPopupConfig {
+         config.transition(.opacity)  // Fade in/out instead of slide
+     }
+     ```
+     */
+    func transition(_ value: AnyTransition) -> Self { self.transition = value; return self }
 }


### PR DESCRIPTION
## Summary
Add support for custom transition animations on vertical popups (TopPopup/BottomPopup).

Closes #199

## Changes
- Add `transition` property to `LocalConfigVertical`
- Add `transition(_ value: AnyTransition)` configuration method
- Update `PopupVerticalStackView` to use custom transition when configured
- Default behavior unchanged (`.move(edge:)` transition)

## Usage
```swift
func configurePopup(config: BottomPopupConfig) -> BottomPopupConfig {
    config
        .transition(.opacity)  // Fade in/out instead of slide
}

// Or combined transitions
func configurePopup(config: TopPopupConfig) -> TopPopupConfig {
    config
        .transition(.scale.combined(with: .opacity))
}
```